### PR TITLE
Add examples [WIP]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .git/
 build/
+examples/build/
 *.so
 *.o
 *.a

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ examples/build/
 *.a
 *.tcc
 *.ttm
+**.log

--- a/examples/captureResponse.idr
+++ b/examples/captureResponse.idr
@@ -1,0 +1,45 @@
+module Main
+
+import Data.Buffer
+import Network.Curl.Easy
+
+-- %foreign "C:alter_ptr,libhelper"
+ffi__alter_ptr : (t -> PrimIO t) -> Ptr t -> PrimIO ()
+
+partial
+writeFunction : Buffer -> (itemsize : Int) -> (len : Int) -> AnyPtr -> PrimIO Int
+writeFunction buf itemsize len anyptr = toPrim $ writeFunction' buf len (prim__castPtr anyptr) where
+    partial
+    passToAlter : Buffer -> Buffer -> IO Buffer
+    passToAlter newbuf storage = do
+        newStorage <- concatBuffers [storage, newbuf]
+        case newStorage of
+            Nothing => idris_crash "concatBuffers returned Nothing"
+            Just x => pure x
+    partial
+    writeFunction' : Buffer -> (len : Int) -> Ptr Buffer -> IO Int
+    writeFunction' newbuf len ptr = do
+        let callback = passToAlter newbuf
+        let primCallback = toPrim . callback
+        primIO $ ffi__alter_ptr primCallback ptr
+        pure len
+
+partial
+main : IO ()
+main = do
+    CURLE_OK <- curl_global_init | c => do
+        putStrLn $ "error in curl_global_init: " ++ show c
+
+    Just cli <- curlEasyInit | Nothing => putStrLn "error in curlEasyInit"
+
+    CURLE_OK <- curlEasySetopt cli CURLOPT_URL "https://google.com" | c => do
+        putStrLn $ "error in curlEasySetopt: " ++ show c
+
+    CURLE_OK <- curlEasySetopt cli CURLOPT_WRITEFUNCTION writeFunction | c => do
+        putStrLn $ "error in curlEasySetopt: " ++ show c
+
+    CURLE_OK <- curlEasyPerform cli | c => do
+        putStrLn $ "error in curlEasyPerform: " ++ show c
+
+    curlEasyCleanup cli
+    curl_global_cleanup

--- a/examples/captureResponse.idr
+++ b/examples/captureResponse.idr
@@ -5,18 +5,12 @@ import Data.IORef
 import Data.Buffer
 import Network.Curl.Easy
 
-partial
-expect : String -> (1 _ : Maybe t) -> t
-expect msg Nothing = idris_crash msg
-expect msg (Just val) = val
-
 writeFunction : Buffer -> (len : Int) -> IORef (List Buffer) -> PrimIO Int
 writeFunction buf len ref = toPrim $ do
     lst <- readIORef ref
     writeIORef ref $ lst ++ [buf]
     rawSize buf
 
-partial
 main : IO ()
 main = do
     CURLE_OK <- curl_global_init | c => do
@@ -37,7 +31,7 @@ main = do
 
     buffers <- readIORef ref
     putStrLn $ "rawSize buffers = " ++ show (length buffers)
-    let buffer = expect "concatBuffers returned Nothing" !(concatBuffers buffers)
+    Just buffer <- concatBuffers buffers | Nothing => putStrLn "concatBuffers returned Nothing"
     bufferSize <- rawSize buffer
     body <- getString buffer 0 bufferSize
     putStrLn body

--- a/examples/captureResponse.idr
+++ b/examples/captureResponse.idr
@@ -5,6 +5,15 @@ import Network.Curl.Easy
 
 -- %foreign "C:alter_ptr,libhelper"
 ffi__alter_ptr : (t -> PrimIO t) -> Ptr t -> PrimIO ()
+-- %foreign ...
+ffi__to_ptr : t -> PrimIO (Ptr t)
+-- %foreign ...
+ffi__from_ptr : Ptr t -> PrimIO t
+
+partial
+expect : String -> (1 _ : Maybe t) -> t
+expect msg Nothing = idris_crash msg
+expect msg (Just val) = val
 
 partial
 writeFunction : Buffer -> (itemsize : Int) -> (len : Int) -> AnyPtr -> PrimIO Int
@@ -13,9 +22,7 @@ writeFunction buf itemsize len anyptr = toPrim $ writeFunction' buf len (prim__c
     passToAlter : Buffer -> Buffer -> IO Buffer
     passToAlter newbuf storage = do
         newStorage <- concatBuffers [storage, newbuf]
-        case newStorage of
-            Nothing => idris_crash "concatBuffers returned Nothing"
-            Just x => pure x
+        pure $ expect "concatBuffers returned Nothing" newStorage
     partial
     writeFunction' : Buffer -> (len : Int) -> Ptr Buffer -> IO Int
     writeFunction' newbuf len ptr = do
@@ -35,11 +42,20 @@ main = do
     CURLE_OK <- curlEasySetopt cli CURLOPT_URL "https://google.com" | c => do
         putStrLn $ "error in curlEasySetopt: " ++ show c
 
+    bufferOpt <- newBuffer 0
+    let buffer = expect "newBuffer returned Nothing" bufferOpt
+    ptrBuffer <- primIO $ ffi__to_ptr buffer
+    CURLE_OK <- curlEasySetopt cli CURLOPT_WRITEDATA (prim__forgetPtr ptrBuffer)
     CURLE_OK <- curlEasySetopt cli CURLOPT_WRITEFUNCTION writeFunction | c => do
         putStrLn $ "error in curlEasySetopt: " ++ show c
 
     CURLE_OK <- curlEasyPerform cli | c => do
         putStrLn $ "error in curlEasyPerform: " ++ show c
+
+    buffer <- primIO $ ffi__from_ptr ptrBuffer
+    bufferSize <- rawSize buffer
+    body <- getString buffer 0 bufferSize
+    freeBuffer buffer
 
     curlEasyCleanup cli
     curl_global_cleanup

--- a/examples/captureResponse.idr
+++ b/examples/captureResponse.idr
@@ -1,14 +1,9 @@
 module Main
 
+import Data.IORef
+
 import Data.Buffer
 import Network.Curl.Easy
-
--- %foreign "C:alter_ptr,libhelper"
-ffi__alter_ptr : (t -> PrimIO t) -> Ptr t -> PrimIO ()
--- %foreign ...
-ffi__to_ptr : t -> PrimIO (Ptr t)
--- %foreign ...
-ffi__from_ptr : Ptr t -> PrimIO t
 
 partial
 expect : String -> (1 _ : Maybe t) -> t
@@ -16,20 +11,11 @@ expect msg Nothing = idris_crash msg
 expect msg (Just val) = val
 
 partial
-writeFunction : Buffer -> (itemsize : Int) -> (len : Int) -> AnyPtr -> PrimIO Int
-writeFunction buf itemsize len anyptr = toPrim $ writeFunction' buf len (prim__castPtr anyptr) where
-    partial
-    passToAlter : Buffer -> Buffer -> IO Buffer
-    passToAlter newbuf storage = do
-        newStorage <- concatBuffers [storage, newbuf]
-        pure $ expect "concatBuffers returned Nothing" newStorage
-    partial
-    writeFunction' : Buffer -> (len : Int) -> Ptr Buffer -> IO Int
-    writeFunction' newbuf len ptr = do
-        let callback = passToAlter newbuf
-        let primCallback = toPrim . callback
-        primIO $ ffi__alter_ptr primCallback ptr
-        pure len
+writeFunction : Buffer -> (len : Int) -> IORef (List Buffer) -> PrimIO Int
+writeFunction buf len ref = toPrim $ do
+    lst <- readIORef ref
+    writeIORef ref $ lst ++ [buf]
+    rawSize buf
 
 partial
 main : IO ()
@@ -39,22 +25,23 @@ main = do
 
     Just cli <- curlEasyInit | Nothing => putStrLn "error in curlEasyInit"
 
-    CURLE_OK <- curlEasySetopt cli CURLOPT_URL "https://google.com" | c => do
+    CURLE_OK <- curlEasySetopt cli CURLOPT_URL "https://www.google.com/" | c => do
         putStrLn $ "error in curlEasySetopt: " ++ show c
 
-    bufferOpt <- newBuffer 0
-    let buffer = expect "newBuffer returned Nothing" bufferOpt
-    ptrBuffer <- primIO $ ffi__to_ptr buffer
-    CURLE_OK <- curlEasySetopt cli CURLOPT_WRITEDATA (prim__forgetPtr ptrBuffer)
-    CURLE_OK <- curlEasySetopt cli CURLOPT_WRITEFUNCTION writeFunction | c => do
-        putStrLn $ "error in curlEasySetopt: " ++ show c
+    ref <- newIORef []
+    CURLE_OK <- curlEasySetopt cli CURLOPT_WRITEFUNCTION
+        (\b,_,l,_ => writeFunction b l ref) | c => do
+          putStrLn $ "error in curlEasySetopt: " ++ show c
 
     CURLE_OK <- curlEasyPerform cli | c => do
         putStrLn $ "error in curlEasyPerform: " ++ show c
 
-    buffer <- primIO $ ffi__from_ptr ptrBuffer
+    buffers <- readIORef ref
+    putStrLn $ "rawSize buffers = " ++ show (length buffers)
+    let buffer = expect "concatBuffers returned Nothing" !(concatBuffers buffers)
     bufferSize <- rawSize buffer
     body <- getString buffer 0 bufferSize
+    putStrLn body
     freeBuffer buffer
 
     curlEasyCleanup cli

--- a/examples/captureResponse.idr
+++ b/examples/captureResponse.idr
@@ -10,7 +10,6 @@ expect : String -> (1 _ : Maybe t) -> t
 expect msg Nothing = idris_crash msg
 expect msg (Just val) = val
 
-partial
 writeFunction : Buffer -> (len : Int) -> IORef (List Buffer) -> PrimIO Int
 writeFunction buf len ref = toPrim $ do
     lst <- readIORef ref
@@ -42,7 +41,8 @@ main = do
     bufferSize <- rawSize buffer
     body <- getString buffer 0 bufferSize
     putStrLn body
-    freeBuffer buffer
+    -- traverse freeBuffer buffers
+    -- freeBuffer buffer
 
     curlEasyCleanup cli
     curl_global_cleanup

--- a/examples/noCapture.idr
+++ b/examples/noCapture.idr
@@ -1,0 +1,19 @@
+module Main
+
+import Network.Curl.Easy
+
+main : IO ()
+main = do
+    CURLE_OK <- curl_global_init | c => do
+        putStrLn $ "error in curl_global_init: " ++ show c
+
+    Just cli <- curlEasyInit | Nothing => putStrLn "error in curlEasyInit"
+
+    CURLE_OK <- curlEasySetopt cli CURLOPT_URL "https://google.com" | c => do
+        putStrLn $ "error in curlEasySetopt: " ++ show c
+
+    CURLE_OK <- curlEasyPerform cli | c => do
+        putStrLn $ "error in curlEasyPerform: " ++ show c
+
+    curlEasyCleanup cli
+    curl_global_cleanup


### PR DESCRIPTION
So, an example that does not capture response body is easy (`examples/noCapture.idr`). But when we need to capture it (`examples/captureResponse.idr`), things get nastier, because `libcurl` expects us to use mutable state for this (`void* userdata` in [their docs](https://curl.haxx.se/libcurl/c/CURLOPT_WRITEFUNCTION.html), `AnyPtr` in [your code](https://github.com/MarcelineVQ/idris2-curl/blob/7afc454a642e1b9d4829a90f9928ec65e3728dc8/src/Network/Curl/Types/CurlEOption.idr#L324)). In my bindings (it was before @ulidtko told me about your project) I implemented only `CURLOPT_WRITEDATA` optcode and passed as `AnyPtr` [my wrapper](https://gitlab.com/aka_dude/idris2-libcurl/-/blob/master/helper-so/helper.c) around `libc`'s `FILE*`. Docs [say](https://curl.haxx.se/libcurl/c/CURLOPT_WRITEDATA.html) that this option doesn't work on win32, so this time I decided to use both optcodes.
I tried to minimize presence of FFI in the code, so this example needs only 3 pretty abstract FFI functions. The question is: what is the best way to implement them? In my project I compile C file to `.so` library and then link it in runtime. Do you know any better way, maybe linking statically? All info I have about FFI in Idris2 is from [here](https://idris2.readthedocs.io/en/latest/). Maybe you have some better documentation (I see you use Elab, but I didn't see any doc on mentioned website)?