### PR TITLE
Fix compilation error

### DIFF
--- a/src/Derive/Newtype.idr
+++ b/src/Derive/Newtype.idr
@@ -1,6 +1,7 @@
 module Derive.Newtype
 
 import public Derive.Common
+import        Util
 %language ElabReflection
 
 -- Derivaton of newtypes, datatypes with a single constructor and single field.
@@ -50,7 +51,7 @@ export
 newtype : String -> Visibility -> TTImp -> Elab ()
 newtype name0 vis ty = do
     name <- inCurrentNS (UN name0)
-    let con = MkTy eFC (mapName ("Mk" ++) name) `(~ty -> ~(IVar eFC name))
+    let con = MkTy eFC (getTTImpFC ty) (mapName ("Mk" ++) name) `(~ty -> ~(IVar eFC name))
     let decl = IData eFC vis $ MkData eFC name (IType eFC) [] [con]
     declare [decl]
 -- e.g `[  ~foo : Type where

--- a/src/Derive/Prim.idr
+++ b/src/Derive/Prim.idr
@@ -26,13 +26,13 @@ import public Derive.Common
 export
 makeHasIO : String -> Visibility -> List Decl -> Elab ()
 makeHasIO funname0 vis ys = do
-    [pclaim@(IClaim pfc pmw pvis _ pty@(MkTy tyfc primname primty))] <- pure ys
+    [pclaim@(IClaim pfc pmw pvis _ pty@(MkTy tyfc namefc primname primty))] <- pure ys
       | _ => fail "bad format"
     let funty = IPi eFC MW AutoImplicit Nothing
                `(HasIO ~(IBindVar eFC "io"))
                (spiderType primty)
         funname = UN funname0
-        funclaim = IClaim eFC pmw vis [] (MkTy tyfc funname funty)
+        funclaim = IClaim eFC pmw vis [] (MkTy tyfc namefc funname funty)
         varnames = map (("var" ++) . show) [0..]
         lvars = IBindVar eFC <$> take (argCount primty) varnames
         rvars = toIVar . UN <$> take (argCount primty) varnames

--- a/src/Network/Curl/Prim/Easy.idr
+++ b/src/Network/Curl/Prim/Easy.idr
@@ -107,7 +107,7 @@ eSetOptPrim opt = do
   let name = UN $ "setOptPrim_" ++ show opt
   z <- quote (paramType opt)
   str <- quote "C:curl_easy_setopt,libcurl,curl/curl.h"
-  let ty = MkTy EmptyFC name `(Ptr HandlePtr -> Int -> ~z -> PrimIO Int)
+  let ty = MkTy EmptyFC EmptyFC name `(Ptr HandlePtr -> Int -> ~z -> PrimIO Int)
   let claim = IClaim EmptyFC MW Private
                 [ForeignFn [str]] ty
   declare [claim] -- generate prim

--- a/src/Network/Curl/Prim/Multi.idr
+++ b/src/Network/Curl/Prim/Multi.idr
@@ -108,7 +108,7 @@ mSetOptPrim opt = do
   let name = UN $ "setOptPrim_" ++ show opt
   z <- quote (paramType opt)
   str <- quote "C:curl_multi_setopt,libcurl,curl/curl.h"
-  let ty = MkTy EmptyFC name `(Ptr HandlePtr -> Int -> ~z -> PrimIO Int)
+  let ty = MkTy EmptyFC EmptyFC name `(Ptr HandlePtr -> Int -> ~z -> PrimIO Int)
   let claim = IClaim EmptyFC MW Private
                 [ForeignFn [str]] ty
   declare [claim] -- generate prim

--- a/src/Util.idr
+++ b/src/Util.idr
@@ -1,6 +1,7 @@
 module Util
 
 import Data.List
+import Derive.Common
 
 infixl 1 <&>
 export
@@ -26,9 +27,10 @@ unzip = foldr (\(x,y),(xs,ys) => (x :: xs, y :: ys)) ([],[])
 -- This is hiiiiiideously slow! maybe it's because I'm using it at elab-time
 export
 unzip3 : List (a,b,c) -> (List a, List b, List c)
-unzip3 [] = ([],[],[])
-unzip3 ((x, (y, z)) :: ls) = let (xs,ys,zs) = unzip3 ls
-                             in (x :: xs, y:: ys, z :: zs)
+unzip3 = Data.Zippable.unzip3
+-- unzip3 [] = ([],[],[])
+-- unzip3 ((x, (y, z)) :: ls) = let (xs,ys,zs) = Util.unzip3 ls
+--                              in (x :: xs, y:: ys, z :: zs)
 
 export
 isJust : Maybe a -> Bool
@@ -52,3 +54,36 @@ total -- the lie
 %foreign "scheme:lambda (x) (blodwen-error-quit x)"
          -- "javascript:lambda:(x)=>{throw new IdrisError(x)}"
 lie_idris_crash : String -> a
+
+export
+getTTImpFC : TTImp -> FC
+getTTImpFC (IVar fc _) = fc
+getTTImpFC (IPi fc _ _ _ _ _) = fc
+getTTImpFC (ILam fc _ _ _ _ _) = fc
+getTTImpFC (ILet fc _ _ _ _ _ _) = fc
+getTTImpFC (ICase fc _ _ _) = fc
+getTTImpFC (ILocal fc _ _) = fc
+getTTImpFC (IUpdate fc _ _) = fc
+getTTImpFC (IApp fc _ _) = fc
+getTTImpFC (INamedApp fc _ _ _) = fc
+getTTImpFC (IAutoApp fc _ _) = fc
+getTTImpFC (IWithApp fc _ _) = fc
+getTTImpFC (ISearch fc _) = fc
+getTTImpFC (IAlternative fc _ _) = fc
+getTTImpFC (IRewrite fc _ _) = fc
+getTTImpFC (IBindHere fc _ _) = fc
+getTTImpFC (IBindVar fc _) = fc
+getTTImpFC (IAs fc _ _ _ _) = fc
+getTTImpFC (IMustUnify fc _ _) = fc
+getTTImpFC (IDelayed fc _ _) = fc
+getTTImpFC (IDelay fc _) = fc
+getTTImpFC (IForce fc _) = fc
+getTTImpFC (IQuote fc _) = fc
+getTTImpFC (IQuoteName fc _) = fc
+getTTImpFC (IQuoteDecl fc _) = fc
+getTTImpFC (IUnquote fc _) = fc
+getTTImpFC (IPrimVal fc _) = fc
+getTTImpFC (IType fc) = fc
+getTTImpFC (IHole fc _) = fc
+getTTImpFC (Implicit fc _) = fc
+getTTImpFC (IWithUnambigNames fc _ _) = fc

--- a/src/Util.idr
+++ b/src/Util.idr
@@ -27,10 +27,9 @@ unzip = foldr (\(x,y),(xs,ys) => (x :: xs, y :: ys)) ([],[])
 -- This is hiiiiiideously slow! maybe it's because I'm using it at elab-time
 export
 unzip3 : List (a,b,c) -> (List a, List b, List c)
-unzip3 = Data.Zippable.unzip3
--- unzip3 [] = ([],[],[])
--- unzip3 ((x, (y, z)) :: ls) = let (xs,ys,zs) = Util.unzip3 ls
---                              in (x :: xs, y:: ys, z :: zs)
+unzip3 [] = ([],[],[])
+unzip3 ((x, (y, z)) :: ls) = let (xs,ys,zs) = Util.unzip3 ls
+                             in (x :: xs, y:: ys, z :: zs)
 
 export
 isJust : Maybe a -> Bool


### PR DESCRIPTION
On newest version of Idris ([70d1505](https://github.com/idris-lang/Idris2/commit/70d1505c5c7aebe1bf5293c78d0f7aa20a0f65d1)) your lib didn't compile, because constructor MkTy [changed](https://github.com/idris-lang/Idris2/blob/70d1505c5c7aebe1bf5293c78d0f7aa20a0f65d1/libs/base/Language/Reflection/TTImp.idr#L110).
I just made the types match, because otherwise I would have spent years understanding Elab's internals, so please check that everything is semantically correct. The main library's code compiles fine though